### PR TITLE
Change pluginList separator from ":" to ";"

### DIFF
--- a/src/main/scala/uk/co/josephearl/sbt/findbugs/CommandLine.scala
+++ b/src/main/scala/uk/co/josephearl/sbt/findbugs/CommandLine.scala
@@ -55,7 +55,7 @@ private[findbugs] trait CommandLine extends Object with Filters {
 
     def addPluginListParameter(arguments: List[String]) = misc.pluginList match {
       case Nil => arguments
-      case plugins => arguments ++ List("-pluginList", plugins mkString ":")
+      case plugins => arguments ++ List("-pluginList", plugins mkString ";")
     }
 
     def addSortByClassParameter(arguments: List[String]) = 


### PR DESCRIPTION
Fixes https://github.com/josephearl/sbt-findbugs/issues/25.

Needs backport to version 2.4.x (sbt 0.13.x)