### PR TITLE
Check for invalid plugins

### DIFF
--- a/src/main/scala/uk/co/josephearl/sbt/findbugs/CommandLine.scala
+++ b/src/main/scala/uk/co/josephearl/sbt/findbugs/CommandLine.scala
@@ -12,6 +12,7 @@
 package uk.co.josephearl.sbt.findbugs
 
 import java.io.File
+import java.nio.file._
 
 import sbt.Keys._
 import sbt._
@@ -69,6 +70,8 @@ private[findbugs] trait CommandLine extends Object with Filters {
     streams.log.debug("Plugin list: " + misc.pluginList.toString)
 
     paths.reportPath foreach (path => IO.createDirectory(path.getParentFile))
+
+    misc.pluginList filter (path => !Files.exists(Paths.get(path))) foreach (path => streams.log.error("Unable to find plugin: " + path))
 
     findbugsCommandLine.map(s => s.replaceAll("\\\\", "/"))
   }


### PR DESCRIPTION
Currently there is no feedback if the specified pluginList is valid (plugins are just silently ignored if invalid).

This PR checks if the plugins specified in `findbugsPluginList` actually exist and logs those that don't to the console.

Needs backport to version 2.4.x (sbt 0.13.x)